### PR TITLE
mapTypeParameters: consider supertypes' type parameters

### DIFF
--- a/src/test/java/io/leangen/geantyref/GenericTypeReflectorTest.java
+++ b/src/test/java/io/leangen/geantyref/GenericTypeReflectorTest.java
@@ -153,6 +153,14 @@ public class GenericTypeReflectorTest extends AbstractGenericsReflectorTest {
         assertEquals(Number.class, ((TypeVariable) parameterTypes[0]).getBounds()[0]);
     }
 
+    public void testConcreteSubtypeResolve() throws NoSuchMethodException {
+        Method m = W.class.getMethod("z");
+        assertEquals(String.class, GenericTypeReflector.erase(
+            GenericTypeReflector.mapTypeParameters(
+                GenericTypeReflector.annotate(m.getGenericReturnType()),
+                GenericTypeReflector.annotate(W.class)).getType()));
+    }
+
     private class N {}
     private class P<S, K> extends N {}
     private class M<U, R> extends P<U, R> {}
@@ -162,4 +170,6 @@ public class GenericTypeReflectorTest extends AbstractGenericsReflectorTest {
     private interface I<T> {<S extends T> S m(S s);}
     private static class Q<G> implements I<G> { @Override public <S extends G> S m(S s) { return null; }
     }
+    private interface Z<T> { default T z() { return null; } }
+    private static class W implements Z<String> {}
 }


### PR DESCRIPTION
Hello from `jdbi`.  We are looking into replacing Guava's type handling with geantyref, for a number of reasons.  However we noticed a difference in how it handles type resolution and think it might be considered a shortcoming.

Currently, resolveTypeMapping only considers the current class's type variables.  It is possible for some of those, however, to be inherited from the super class.

Guava handles this: https://github.com/google/guava/blob/master/guava/src/com/google/common/reflect/TypeResolver.java#L388-L392 but geantyref does not.

Is this an intentional limitation?  If not, can we extend the current algorithm to include supertypes?  Thanks!