### PR TITLE
Add Automatic Module Name io.leangen.geantyref

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                          <Automatic-Module-Name>io.leangen.geantyref</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This automatic module name makes geantyref usable as an automatic module
for any developer using this project in their JPMS project.

Closes #10 