### PR TITLE
TypeToken needs to return the hash of the type

### DIFF
--- a/src/main/java/io/leangen/geantyref/TypeToken.java
+++ b/src/main/java/io/leangen/geantyref/TypeToken.java
@@ -91,6 +91,6 @@ public abstract class TypeToken<T> {
 
     @Override
     public int hashCode() {
-        return type.hashCode();
+        return getType().hashCode();
     }
 }


### PR DESCRIPTION
No idea why that worked for the original author. I needed this change
to make the test pass.
