### PR TITLE
feat: add support for jpms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <release>8</release>
+                    <source>9</source>
+                    <target>9</target>
+                    <release>9</release>
                 </configuration>
             </plugin>
 

--- a/src/main/java/io/leangen/geantyref/AnnotatedArrayTypeImpl.java
+++ b/src/main/java/io/leangen/geantyref/AnnotatedArrayTypeImpl.java
@@ -45,4 +45,9 @@ class AnnotatedArrayTypeImpl extends AnnotatedTypeImpl implements AnnotatedArray
     public String toString() {
         return componentType.toString() + " " + annotationsString() + "[]";
     }
+
+    @Override
+    public AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
 }

--- a/src/main/java/io/leangen/geantyref/AnnotatedParameterizedTypeImpl.java
+++ b/src/main/java/io/leangen/geantyref/AnnotatedParameterizedTypeImpl.java
@@ -57,4 +57,9 @@ class AnnotatedParameterizedTypeImpl extends AnnotatedTypeImpl implements Annota
         typeName.append(rawName);
         return annotationsString() + typeName + "<" + typesString(typeArguments) + ">";
     }
+
+    @Override
+    public AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
 }

--- a/src/main/java/io/leangen/geantyref/AnnotatedTypeVariableImpl.java
+++ b/src/main/java/io/leangen/geantyref/AnnotatedTypeVariableImpl.java
@@ -46,4 +46,9 @@ class AnnotatedTypeVariableImpl extends AnnotatedTypeImpl implements AnnotatedTy
     public String toString() {
         return annotationsString() + ((TypeVariable<?>) type).getName();
     }
+
+    @Override
+    public AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
 }

--- a/src/main/java/io/leangen/geantyref/AnnotatedWildcardTypeImpl.java
+++ b/src/main/java/io/leangen/geantyref/AnnotatedWildcardTypeImpl.java
@@ -87,4 +87,9 @@ class AnnotatedWildcardTypeImpl extends AnnotatedTypeImpl implements AnnotatedWi
             }
         }
     }
+
+    @Override
+    public AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * License: Apache License, Version 2.0
+ * See the LICENSE file in the root directory or at <a href="http://www.apache.org/licenses/LICENSE-2">apache.org</a>.
+ */
+
+/**
+ * GenTyRef - Type reflection library for Java
+ */
+module io.leangen.geantyref {
+    requires static java.desktop;
+    exports io.leangen.geantyref;
+}


### PR DESCRIPTION
## Summary

Adds a `module-info.java` so that Geantyref can be used from Modular Java apps.

Fixes and closes leangen/geantyref#28 and leangen/geantyref#26

## Changelog

- chore: add mvn build wrapper
- chore: add compile run and srcroot for java9
- chore: add java9-compliant implementations where needed
- chore: add mrjar output
- chore: remove `Automatic-Module-Name`