### PR TITLE
Fix issue #32, Method GenericTypeReflector#getArrayComponentType(Type) throws NullPointerException when parameter is a non-array Class type

### DIFF
--- a/src/main/java/io/leangen/geantyref/GenericTypeReflector.java
+++ b/src/main/java/io/leangen/geantyref/GenericTypeReflector.java
@@ -441,7 +441,12 @@ public class GenericTypeReflector {
     public static AnnotatedType getArrayComponentType(AnnotatedType type) {
         if (type.getType() instanceof Class) {
             Class<?> clazz = (Class<?>)type.getType();
-            return new AnnotatedTypeImpl(clazz.getComponentType(), clazz.getAnnotations(), type.getAnnotatedOwnerType());
+            if (clazz.getComponentType() == null) {
+                return null;
+            }
+            else {
+                return new AnnotatedTypeImpl(clazz.getComponentType(), clazz.getAnnotations(), type.getAnnotatedOwnerType());
+            }
         } else if (type instanceof AnnotatedArrayType) {
             AnnotatedArrayType aType = (AnnotatedArrayType) type;
             return aType.getAnnotatedGenericComponentType();

--- a/src/test/java/io/leangen/geantyref/GenericTypeReflectorTest.java
+++ b/src/test/java/io/leangen/geantyref/GenericTypeReflectorTest.java
@@ -270,6 +270,26 @@ public class GenericTypeReflectorTest extends AbstractGenericsReflectorTest {
         assertAnnotationsPresent(annotatedOwnerType.getAnnotatedActualTypeArguments()[0], A4.class, A1.class);
     }
 
+    public void testArrayComponentType1() {
+        // N is not an array class. Per the contract of the method, it should return null.
+        // NOTE: This is a regression test for issue #32
+        Type elementType = GenericTypeReflector.getArrayComponentType(N.class);
+        assertEquals(null, elementType);
+    }
+
+    public void testArrayComponentType2() {
+        // String[] is an array class. Per the contract of the method, it should return String.class.
+        Type elementType = GenericTypeReflector.getArrayComponentType(String[].class);
+        assertEquals(String.class, elementType);
+    }
+
+    public void testArrayComponentType3() {
+        // gat1 is an generic array type. Per the contract of the method, it should return List<String>,
+        // which is stored in gate1.
+        Type elementType = GenericTypeReflector.getArrayComponentType(gat1);
+        assertEquals(gate1, elementType);
+    }
+
     private class N {}
     private class P<S, K> extends N {}
     private class L<S, K> extends P<List<K>, List<Map<K, S>>> {}
@@ -289,6 +309,9 @@ public class GenericTypeReflectorTest extends AbstractGenericsReflectorTest {
 
     private static AnnotatedType t1 = new TypeToken<@A1 Optional<@A2 Map<@A3 String, @A4 Integer @A5 []>>>(){}.getAnnotatedType();
     private static AnnotatedType t2 = new TypeToken<@A5 Optional<@A4 Map<@A2 String, @A3 Integer @A1 []>>>(){}.getAnnotatedType();
+
+    private static Type gat1 = new TypeToken<List<String> []>(){}.getType();
+    private static Type gate1 = new TypeToken<List<String>>(){}.getType();
 
     private class Outer { @A1 class Inner { @A2 class Innermost {}}}
 


### PR DESCRIPTION
This PR includes small changes to fix issue #32. In particular, the following test fails on (current) master (and v1.3.16, and v2.0.0), but passes with this PR:

```
    public void testArrayComponentType1() {
        // N is not an array class. Per the contract of the method, it should return null.
        // NOTE: This is a regression test for issue #32
        Type elementType = GenericTypeReflector.getArrayComponentType(N.class);
        assertEquals(null, elementType);
    }
```

I know it's easily visible elsewhere in the UI, but I'll copy the code changes here for convenience. It's fairly innocuous, IMO:

```
--- a/src/main/java/io/leangen/geantyref/GenericTypeReflector.java
+++ b/src/main/java/io/leangen/geantyref/GenericTypeReflector.java
@@ -441,12 +441,7 @@ public class GenericTypeReflector {
     public static AnnotatedType getArrayComponentType(AnnotatedType type) {
         if (type.getType() instanceof Class) {
             Class<?> clazz = (Class<?>)type.getType();
-            if (clazz.getComponentType() == null) {
-                return null;
-            }
-            else {
-                return new AnnotatedTypeImpl(clazz.getComponentType(), clazz.getAnnotations(), type.getAnnotatedOwnerType());
-            }
+            return new AnnotatedTypeImpl(clazz.getComponentType(), clazz.getAnnotations(), type.getAnnotatedOwnerType());
         } else if (type instanceof AnnotatedArrayType) {
             AnnotatedArrayType aType = (AnnotatedArrayType) type;
             return aType.getAnnotatedGenericComponentType();
```

I also added a couple more tests to make sure I understood the problem and didn't break anything.

I hope this all makes sense. Please feel free to send any questions or comments my way!